### PR TITLE
Refactor session handling in image and watcher APIs

### DIFF
--- a/backend/router/vector_db_api.py
+++ b/backend/router/vector_db_api.py
@@ -2,7 +2,6 @@ from typing import Optional
 import indexer
 
 from fastapi import APIRouter, HTTPException
-from database.database import engine
 import indexer.vector_db
 from router.file_api import getFolderPath
 from database.utils import get_directory_id, query_images_by_id_list

--- a/backend/router/watcher_api.py
+++ b/backend/router/watcher_api.py
@@ -5,7 +5,7 @@ from sqlmodel import Session, delete, select, text
 from typing import List
 from PIL import Image as ImageLoader
 from database.models import Image, Directory
-from database.database import get_session, engine
+from database.database import get_session
 
 import indexer
 

--- a/backend/watcher/watchdogService.py
+++ b/backend/watcher/watchdogService.py
@@ -150,8 +150,8 @@ class ChangedFile:
 def process_file(file: ChangedFile, id):
     print(f"[watchdog - Processing - {id}] {file.type} {file.src} -> {file.dst if file.dst else 'N/A'}")
     file_path = file.src.as_posix()
-    if file.type == FileChangeType.CREATED or file.type == FileChangeType.MODIFIED:
-        with Session(engine) as session:
+    with Session(engine) as session:
+        if file.type == FileChangeType.CREATED or file.type == FileChangeType.MODIFIED:
             try:
                 if inesrt_or_update_image(file_path, session) is not None:
                     print(f"[watchdog - Result - {id}] {file.type} image: {file_path}")
@@ -163,17 +163,17 @@ def process_file(file: ChangedFile, id):
             except Exception as e:
                 print(f'[watchdog - Result - {id}] Error during {file.type}: {e}')
 
-    elif file.type == FileChangeType.DELETED:
-        if delete_image(file.src):
-            print(f"[watchdog - Result - {id}] File deleted: {file_path}")
-        else:
-            print(f"[watchdog - Result - {id}] Error deleting file: {file_path}")
+        elif file.type == FileChangeType.DELETED:
+            if delete_image(file.src, session):
+                print(f"[watchdog - Result - {id}] File deleted: {file_path}")
+            else:
+                print(f"[watchdog - Result - {id}] Error deleting file: {file_path}")
 
-    elif file.type == FileChangeType.MOVED:
-        if move_image_path(file.src, file.dst, False):
-            print(f"[watchdog - Result - {id}] Move image: {file.src} -> {file.dst}")
-        else:
-            print(f"[watchdog - Result - {id}] Error moving image: {file.src} -> {file.dst}")
+        elif file.type == FileChangeType.MOVED:
+            if move_image_path(file.src, file.dst, False, session):
+                print(f"[watchdog - Result - {id}] Move image: {file.src} -> {file.dst}")
+            else:
+                print(f"[watchdog - Result - {id}] Error moving image: {file.src} -> {file.dst}")
 
 def add_file(src: Path, type: str, mtime: datetime, dst: Optional[Path] = None):
     global last_add_time


### PR DESCRIPTION
Refactored functions in sqlite_api.py to accept a Session object as a parameter instead of creating their own, improving testability and consistency. Updated watcher_api.py and watchdogService.py to use the new session-based signatures. Adjusted test_main.py to patch the engine for isolated testing and ensure dependency overrides use the correct session. Cleaned up unused imports and improved code clarity.