### PR TITLE
Refactor and expand test suite structure

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,47 @@
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+import database.database
+import database.utils
+
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool  
+
+import watcher.watchdogService
+
+import indexer
+indexer.COLLECTION_NAME = "test_collection"
+
+from main import app
+
+@pytest.fixture(name="session")
+def session_fixture(monkeypatch):
+    test_engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+
+    # Patch the global engine in your app code
+    monkeypatch.setattr(database.database, "engine", test_engine)
+    monkeypatch.setattr(database.utils, "engine", test_engine)
+    monkeypatch.setattr(watcher.watchdogService, "engine", test_engine)
+    assert database.database.engine is test_engine
+    assert database.utils.engine is test_engine
+    assert watcher.watchdogService.engine is test_engine
+
+    SQLModel.metadata.create_all(test_engine)
+
+    with Session(test_engine) as session:
+        yield session
+
+@pytest.fixture(name="client")  
+def client_fixture(session: Session):  
+    def get_session_override():  
+        return session
+
+    app.dependency_overrides[database.database.get_session] = get_session_override  
+
+    client = TestClient(app)  
+    yield client  
+    app.dependency_overrides.clear()  

--- a/backend/tests/constants.py
+++ b/backend/tests/constants.py
@@ -1,0 +1,7 @@
+from router.file_api import BASE_DIR
+
+PATH_HUSKY_IMAGE = "husky_1.jpg"
+PATH_HUSKY_IMAGE_2 = "folder/husky_2.jpg"
+PATH_ROBOT_IMAGE = "robot_1.jpg"
+PATH_ROBOT_IMAGE_2 = "folder/robot_2.jpg"
+PATH_FLOWER_IMAGE = "flower.jpg"

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -1,0 +1,142 @@
+from tests.utils import *
+
+from pathlib import Path
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from router.file_api import getPathOfImageFile, BASE_DIR
+from router.sqlite_api import delete_image, inesrt_or_update_image
+from tests.constants import *
+
+
+def test_query_images(client: TestClient, session: Session):
+
+    def query(text: str, use_text_embed: bool, use_bm25: bool, use_joint_embed: bool):
+        assert use_text_embed or use_bm25 or use_joint_embed, "At least one of the query methods must be used"
+        response = client.get("/api/query", params={
+            "text": text,
+            "use_text_embed": use_text_embed,
+            "use_bm25": use_bm25,
+            "use_joint_embed": use_joint_embed
+        })
+        
+        data = sorted(response.json(), key=lambda x: x['distance'], reverse=True) 
+        assert response.status_code == 200
+        assert len(data) >= 2 # at least two result should be returned
+        assert text in data[0]["filename"] and text in data[1]["filename"]
+
+    clear_vector_db()
+    inesrt_or_update_image(PATH_HUSKY_IMAGE, session)
+    inesrt_or_update_image(PATH_HUSKY_IMAGE_2, session)
+    inesrt_or_update_image(PATH_ROBOT_IMAGE, session)
+    inesrt_or_update_image(PATH_ROBOT_IMAGE_2, session)
+
+    wait_before_read_vecdb()
+
+    response = client.get("/image")
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data) == 4
+
+    response = client.get("/api/query", params={"text": "husky", "use_text_embed": False, "use_bm25": False, "use_joint_embed": False})
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) == 0
+
+    query("husky", True, True, True)  
+    query("robot", True, True, True) 
+    query("husky", True, False, False)
+    query("robot", True, False, False)
+    query("husky", False, True, False)
+    query("robot", False, True, False)
+    query("husky", False, False, True)
+    query("robot", False, False, True)
+
+def test_query_images_within_folder(client: TestClient, session: Session, tmp_path: Path):
+
+    def query(text: str, path: str):
+        response = client.get("/api/query", params={
+            "text": text,
+            "use_text_embed": True,
+            "use_bm25": True,
+            "use_joint_embed": True,
+            "path": path
+        })
+        assert response.status_code == 200
+        data = sorted(response.json(), key=lambda x: x['distance'], reverse=True) 
+        
+        return data
+
+    clear_vector_db()
+    inesrt_or_update_image(PATH_HUSKY_IMAGE, session)
+    inesrt_or_update_image(PATH_HUSKY_IMAGE_2, session)
+    inesrt_or_update_image(PATH_ROBOT_IMAGE, session)
+    inesrt_or_update_image(PATH_ROBOT_IMAGE_2, session)
+
+    wait_before_read_vecdb()
+
+    folder = "folder"
+    folder_path = Path(BASE_DIR / folder).resolve()
+
+    assert folder_path.is_dir()
+    
+    data = query("husky", folder)
+    assert len(data) >= 1
+    assert "husky" in data[0]["filename"]
+    
+    for item in data:
+        assert item["full_path"].startswith(folder_path.as_posix())
+
+
+    folder_path = Path(BASE_DIR).resolve()
+
+    assert folder_path.is_dir()
+    
+    data = query("robot", folder_path.as_posix())
+    assert len(data) >= 1
+    assert "robot" in data[0]["filename"]
+    
+    for item in data:
+        assert item["full_path"].startswith(folder_path.as_posix())
+
+
+    # test query never seen dir
+    assert tmp_path.is_dir()
+    response = client.get("/api/query", 
+        params={
+            "text": "husky", 
+            "use_text_embed": True, "use_bm25": True, "use_joint_embed": True,
+            "path": tmp_path.as_posix()
+        }
+    )
+
+    assert response.status_code == 404
+
+    # test query empty dir
+
+    image_path = getPathOfImageFile(PATH_FLOWER_IMAGE)
+    target_image_path = tmp_path / PATH_FLOWER_IMAGE
+
+    copy_file(image_path.parent, target_image_path.parent, image_path.name)
+
+    # insert image and delete it to create directory entry of tmp folder
+    inesrt_or_update_image(target_image_path, session)
+    delete_image(target_image_path, session)
+
+    wait_before_read_vecdb()
+
+    response = client.get("/api/query", 
+        params={
+            "text": "husky", 
+            "use_text_embed": True, "use_bm25": True, "use_joint_embed": True,
+            "path": tmp_path.as_posix()
+        }
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 0
+
+
+

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -1,0 +1,63 @@
+import indexer
+import time
+import shutil
+from pathlib import Path
+from pathlib import Path
+import indexer
+
+def copy_file(src_folder: Path, dst_folder: Path, filename: str):
+    src = src_folder / filename
+    dst = dst_folder / filename
+    assert src.is_file()
+    shutil.copy(src, dst)
+    assert dst.is_file(), "copy failed"
+
+
+def move_file(src_folder: Path, dst_folder: Path, filename: str):
+    src = src_folder / filename
+    dst = dst_folder / filename
+    assert src.is_file()
+    assert dst.exists() == False, "use replace_file instead"
+    shutil.move(src, dst)
+
+    assert dst.is_file() and src.exists() == False, "move failed"
+
+def delete_file(filePath: Path):
+    assert filePath.is_file()
+    filePath.unlink()
+
+    assert filePath.exists() == False, "delete failed"
+
+
+def rename_file(src_folder: Path, filename: str, new_filename: str):
+    file = src_folder / filename
+    new_file = src_folder / new_filename
+    assert file.is_file()
+    assert new_file.exists() == False, "file already exists, use replace_file instead"
+    file.rename(new_file)
+
+def replace_file(src_folder: Path, dst_folder: Path, filename: str):
+    file = src_folder / filename
+    new_file = dst_folder / filename
+    assert file.is_file()
+    assert new_file.is_file(), "no file to replace, use move_file instead"
+    file.replace(new_file)
+
+
+def wait_before_read_vecdb():
+    time.sleep(0.5)
+
+
+def clear_vector_db():
+    """Clear the vector database for testing purposes."""
+        # Clear the vector database collection before each test
+    if indexer.is_collection_exist(indexer.COLLECTION_NAME) == False:
+        indexer.create_embed_db(indexer.COLLECTION_NAME)
+
+    while True:
+        ids = [data[indexer.FIELD_ID] for data in indexer.list_data(indexer.COLLECTION_NAME)]
+        if len(ids) == 0:
+            break
+        delete = indexer.delete_by_list(indexer.COLLECTION_NAME, ids)
+        if delete == False:
+            raise RuntimeError("Failed to clear vector database collection")


### PR DESCRIPTION
Moved and split tests into a dedicated 'tests' package, separating database and query tests into 'test_db.py' and 'test_query.py'. Added shared fixtures in 'conftest.py', constants in 'constants.py', and utility functions in 'utils.py' to improve test maintainability and reusability.