### PR TITLE
Add CORS middleware to FastAPI app

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from router import vector_db_api, file_api, sqlite_api, watcher_api
 from contextlib import asynccontextmanager
+from fastapi.middleware.cors import CORSMiddleware
 
 from fastapi import FastAPI, Depends
 from sqlmodel import Session, select
@@ -22,12 +23,25 @@ async def lifespan(app: FastAPI):
 
     watcher.fs_watcher.stop()
 
+origins = [
+    "http://localhost:5173",   # Vite
+    "http://127.0.0.1:5173",   # Alternate
+]
+
 app = FastAPI(lifespan=lifespan)
 
 app.include_router(vector_db_api.router)
 app.include_router(file_api.router)
 app.include_router(sqlite_api.router)
 app.include_router(watcher_api.router)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,             # Allow specific origins
+    allow_credentials=True,
+    allow_methods=["*"],               # GET, POST, PUT, DELETE, etc
+    allow_headers=["*"],               # Allow all headers
+)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
Introduced CORSMiddleware to allow requests from local development origins. This enables frontend applications running on localhost:5173 to interact with the backend API during development.