### PR TITLE
Fix: thumbnail path handling for images

### DIFF
--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -146,7 +146,7 @@ def test_update_images(client: TestClient, session: Session, tmp_images_path: Pa
     assert response.status_code == 200
     data = response.json()
     assert id == data["id"]
-    assert last_modified != data["last_modified"]
+    assert data["last_modified"] == datetime.fromtimestamp((tmp_images_path / PATH_HUSKY_IMAGE).stat().st_mtime).isoformat()
 
     assert data["filename"] == HUSKY_IMAGE
     assert data["full_path"] == (tmp_images_path / PATH_HUSKY_IMAGE).resolve().as_posix()

--- a/backend/tests/test_watcher.py
+++ b/backend/tests/test_watcher.py
@@ -197,6 +197,7 @@ def test_watchdog_modify(client: TestClient, session: Session, fs_watcher: Watch
     assert response.status_code == 200
     data = response.json()
     thumbnail_path = data["thumbnail_path"]
+    assert Path(thumbnail_path).is_absolute() == False
     assert Path(router.file_api.THUMBNAIL_DIR / thumbnail_path).exists()
 
     new_file = base / ("renamed_" + HUSKY_IMAGE) # rename to new file to prevent genai cache
@@ -215,6 +216,7 @@ def test_watchdog_modify(client: TestClient, session: Session, fs_watcher: Watch
     data = response.json()
     new_thumbnail_path = data["thumbnail_path"]
     assert new_thumbnail_path != thumbnail_path
+    assert Path(new_thumbnail_path).is_absolute() == False
     assert Path(router.file_api.THUMBNAIL_DIR / new_thumbnail_path).exists()
     assert Path(router.file_api.THUMBNAIL_DIR / thumbnail_path).exists() == False  # old thumbnail should be deleted
 

--- a/backend/tests/test_watcher_api.py
+++ b/backend/tests/test_watcher_api.py
@@ -24,6 +24,11 @@ def test_watchdog_add_api(client: TestClient, session: Session, fs_watcher: Watc
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 3, "Expected 3 images in the base folder"
+    firstImage = data[0]
+    assert firstImage["thumbnail_path"] is not None
+    thumbnail_path = Path(firstImage["thumbnail_path"])
+    assert thumbnail_path.is_absolute() == False
+    assert (router.file_api.THUMBNAIL_DIR / thumbnail_path).exists()
 
     response = client.get("/watcher/listening")
     assert response.status_code == 200
@@ -85,6 +90,11 @@ def test_watchdog_remove_and_clear(client: TestClient, session: Session, fs_watc
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 3, "Expected 3 images in the base folder"
+    firstImage = data[0]
+    assert firstImage["thumbnail_path"] is not None
+    thumbnail_path = Path(firstImage["thumbnail_path"])
+    assert (router.file_api.THUMBNAIL_DIR / thumbnail_path).exists()
+    
 
     response = client.get("/watcher/listening")
     assert response.status_code == 200
@@ -110,3 +120,5 @@ def test_watchdog_remove_and_clear(client: TestClient, session: Session, fs_watc
     response = client.get("/image/folder", params={"path": base.as_posix()})
     assert response.status_code == 200
     assert len(response.json()) == 0, "Expected no images in the base folder after removal"
+
+    assert not (router.file_api.THUMBNAIL_DIR / thumbnail_path).exists(), "Thumbnail should be deleted after removing images"


### PR DESCRIPTION
Thumbnail paths are stored as base names instead of absolute paths, and all thumbnail file operations use the THUMBNAIL_DIR for correct file resolution. Tests have been updated to verify the behavior, ensuring thumbnails are created, updated, and deleted as expected.