### PR TITLE
Track image file size in database and APIs

### DIFF
--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -30,3 +30,4 @@ class Image(SQLModel, table=True):
     directory: Optional[Directory] = Relationship(back_populates="images")
 
     last_modified: Optional[datetime] = Field(default=None)
+    file_size: Optional[int] = Field(default=None)  # in bytes

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,13 +12,11 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool  
 
 import indexer
-indexer.COLLECTION_NAME = "test_collection"
 
 from main import app
 import watcher
 
 import router.file_api
-indexer.create_embed_db(indexer.COLLECTION_NAME)
 
 indexer.genai_api.delete_uploaded_files()
 
@@ -38,8 +36,14 @@ def session_fixture(monkeypatch):
         yield session
 
 @pytest.fixture(name="db_session")
-def vector_db_fixture():
-    clear_vector_db()
+def vector_db_fixture(monkeypatch):
+    monkeypatch.setattr(indexer, "COLLECTION_NAME", "test_collection")
+    assert indexer.COLLECTION_NAME is "test_collection"
+
+    if not indexer.is_collection_exist(indexer.COLLECTION_NAME):
+        indexer.create_embed_db(indexer.COLLECTION_NAME)
+    else:
+        clear_vector_db()
 
 @pytest.fixture(name="client")  
 def client_fixture(session: Session, db_session):  

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -2,15 +2,10 @@
 from tests.utils import *
 from tests.constants import *
 
-import indexer
-indexer.COLLECTION_NAME = "test_collection"
-
 from datetime import datetime
 from pathlib import Path
 from fastapi.testclient import TestClient
 import pytest
-
-import indexer
 
 from router.file_api import getPathOfImageFile, BASE_DIR
 import router.file_api
@@ -125,6 +120,7 @@ def test_add_images(client: TestClient):
 
 def test_update_images(client: TestClient, session: Session, tmp_images_path: Path):
     inesrt_or_update_image((tmp_images_path / PATH_HUSKY_IMAGE).as_posix(), session)
+    # rename the image to test replacement
     rename_file(tmp_images_path / SUBFOLDER, HUSKY_IMAGE_2, HUSKY_IMAGE)
     
 
@@ -132,7 +128,6 @@ def test_update_images(client: TestClient, session: Session, tmp_images_path: Pa
     assert response.status_code == 200
     data = response.json()
     id = data["id"]
-    last_modified = data["last_modified"]
     thumbnail_path = Path(data["thumbnail_path"])
     assert data["filename"] == HUSKY_IMAGE
     assert data["full_path"] == (tmp_images_path / PATH_HUSKY_IMAGE).resolve().as_posix()

--- a/backend/watcher/watchdogService.py
+++ b/backend/watcher/watchdogService.py
@@ -1,5 +1,6 @@
 # watcher.py
 from datetime import datetime
+from os import stat_result
 import os
 import time
 from typing import Dict, Optional
@@ -54,7 +55,6 @@ def is_image(file: Path):
 
 def only_update_metadata(file: Path):
     image = query_images_by_path(file)
-    mtime = file.stat().st_mtime
 
     if image is None:
         return False
@@ -62,7 +62,11 @@ def only_update_metadata(file: Path):
     if image.last_modified is None:
         return False
     
-    return datetime.fromtimestamp(mtime) == image.last_modified
+    file_stat: stat_result = file.stat()
+    mtime = file_stat.st_mtime
+    file_size = file_stat.st_size
+    
+    return datetime.fromtimestamp(mtime) == image.last_modified and file_size == image.file_size
         
 class FileChangeType(Enum):
     CREATED = "created"


### PR DESCRIPTION
Adds a file_size field to the Image model and updates API logic to check both last_modified and file_size for change detection. This improves accuracy when determining if an image file has been modified, and ensures metadata is updated only when necessary. Related tests and watcher logic are updated accordingly.